### PR TITLE
Added default settings.xml for Bamboo

### DIFF
--- a/support-bamboo/settings.xml
+++ b/support-bamboo/settings.xml
@@ -1,0 +1,26 @@
+<settings>
+
+  <servers>
+    <server>
+      <id>snapshots</id>
+      <username>ddf</username>
+      <password>${env.NEXUS_PASSWORD}</password>
+    </server>
+  </servers>
+  
+  <profiles>
+    <profile>
+      <id>codice</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <repository.host>artifacts.codice.org</repository.host>
+        <snapshots.repository.url>http://${repository.host}/content/repositories/snapshots</snapshots.repository.url>
+        <releases.repository.url>http://${repository.host}/content/repositories/releases</releases.repository.url>
+      </properties>
+    </profile>
+  </profiles>
+  
+</settings>
+


### PR DESCRIPTION
@shaundmorris: Added settings.xml file needed to do mvn deploy. Once this has been reviewed and merged I'll be able to finish configuring Bamboo to automatically upload snapshot artifacts to Nexus after successful builds.