### PR TITLE
DDF-1327: Added scripts for Bamboo CI builds

### DIFF
--- a/support-bamboo/README.md
+++ b/support-bamboo/README.md
@@ -1,0 +1,50 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+
+This directory contains files used to configure CI builds in Bamboo
+
+## Setting up a Bamboo Plan Using Scripts
+
+These scripts are used to integrate Bamboo CI builds with GitHub pull requests. They allow Bamboo to checkout the code changes corresponding to a pull request (PR) and update the status of the build on the GitHub page. They should be used as follows:
+
+1. Create a separate plan for GitHub PR builds.
+2. Add as many stages as needed for the build and as many jobs as needed in each stage
+3. Within each job, add the following tasks in the order shown:
+  * Source Code Checkout -- checkout ddf-support
+  * Script -- run buildStarted.sh to update GitHub build status to in-progress. Only needed in first job of the build
+  * Script -- run checkoutRepo.sh to checkout the correct PR
+  * Any tasks needed for the build
+  * Inject Bamboo variables -- Load variable jobResult from the job.properties file. Will only run if previous tasks succeeded  
+
+    `Final Tasks`
+  * Script -- run jobComplete.sh. If variable jobResult was not injected, sends a failure notice to the PR status on GitHub
+4. Add a Notification stage at the end of the build plan and give it a job with the following tasks
+  * Source Code Checkout -- checkout ddf-support
+  * Script -- run planComplete.sh to send a success notice to the PR status on GitHub
+
+**Note:** These scripts require a number of variables that are not present in a default Bamboo build. To make the plan run properly, use the Bamboo REST api `/queue/{projectKey}-{buildKey}-{buildNumber}` endpoint to trigger a custom build, and pass in the following variables:
+* pull_num: The number used to identify the PR
+* pull_sha: The hash of the commit that needs to be built
+
+## Configuring Maven Builds Using settings.xml
+
+This file is used to configure Maven with necessary credentials for downloading artifacts during the build, and to point it to the release and snapshot repositories where those artifacts are stored. It should be used as follows:
+
+1. Create a Bamboo Maven task
+2. In the Goal field, specify the settings file using the '-s' flag in addition to the goal that Maven should run
+
+  `-s ${bamboo.build.working.directory}/ddf-support/support-bamboo/settings.xml clean install`
+
+3. In the Environment variables field, specify the password that Maven should use for the code repositories
+
+  `NEXUS_PASSWORD=${bamboo.ddf.password}`

--- a/support-bamboo/buildStarted.sh
+++ b/support-bamboo/buildStarted.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Update the GitHub PR status to in-progress. Should be run at the start of the plan after ddf-support has been checked out.
+
+echo "Notifying GitHub that build has started"
+
+data='{"state": "pending", "context": "bamboo", "description": "The Bamboo build is in progress", "target_url": "'"${bamboo_codice_bamboo_url}/browse/${bamboo_planKey}-${bamboo_buildNumber}\"}"
+curl -H "Authorization: token ${bamboo_github_api_password}" --request POST --data "${data}" ${bamboo_github_api_url}/repos/codice/${bamboo_repo_name}/statuses/${bamboo_pull_sha} > /dev/null

--- a/support-bamboo/checkoutRepo.sh
+++ b/support-bamboo/checkoutRepo.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Checkout code from the PR branch. Forces clean build
+
+if [ -d "${repo_name}" ]; then
+	echo "Cleaning directory ${bamboo_build_working_directory}/${repo_name}"
+	rm -rf ${repo_name}
+fi
+
+echo "Initializing empty git repository in ${bamboo_build_working_directory}/${bamboo_repo_name}/.git"
+mkdir ${bamboo_repo_name}
+cd ${bamboo_repo_name}
+git init
+
+echo "Fetching '+refs/pull/${bamboo_pull_num}/head' from '${bamboo_repository_git_repositoryUrl}'. Will try to do a shallow fetch."
+git remote add origin ${bamboo_repository_git_repositoryUrl}
+git fetch --depth 1 origin +refs/pull/${bamboo_pull_num}/head
+
+echo "Checking out revision ${bamboo_pull_sha}"
+git checkout FETCH_HEAD

--- a/support-bamboo/job.properties
+++ b/support-bamboo/job.properties
@@ -1,0 +1,2 @@
+# Used to determine whether the current job has failed. Should be injected using the "Inject Bamboo Variables" task after all non-final tasks have completed
+jobResult=Success

--- a/support-bamboo/jobComplete.sh
+++ b/support-bamboo/jobComplete.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Check if job failed and, if so, update the GitHub PR status accordingly. Should be run at the end of every job.
+
+if [ "${bamboo_inject_jobResult}" != "Success" ]; then
+	echo "The build could not complete due to an error. Notifying GitHub of build failure"
+	
+	data='{"state": "failure", "context": "bamboo", "description": "The Bamboo build could not complete due to an error!", "target_url": "'"${bamboo_codice_bamboo_url}/browse/${bamboo_planKey}-${bamboo_buildNumber}\"}"
+    curl -H "Authorization: token ${bamboo_github_api_password}" --request POST --data "${data}" ${bamboo_github_api_url}/repos/codice/${bamboo_repo_name}/statuses/${bamboo_pull_sha} > /dev/null
+fi

--- a/support-bamboo/planComplete.sh
+++ b/support-bamboo/planComplete.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Update the GitHub PR status to success. Should be run in its own stage at the end of the plan.
+
+echo "The build has completed. Notifying GitHub of build success"
+
+data='{"state": "success", "context": "bamboo", "description": "The Bamboo build passed", "target_url": "'"${bamboo_codice_bamboo_url}/browse/${bamboo_planKey}-${bamboo_buildNumber}\"}"
+curl -H "Authorization: token ${bamboo_github_api_password}" --request POST --data "${data}" ${bamboo_github_api_url}/repos/codice/${bamboo_repo_name}/statuses/${bamboo_pull_sha} > /dev/null


### PR DESCRIPTION
The scripts will be used in the Bamboo PR build plans to notify the GitHub PR of the build status (like Travis) and checkout the appropriate code for the build.

@lessarderic 