### PR TITLE
DDF-1335: Added exclusion for vulnerability CVE-2011-2730

### DIFF
--- a/support-owasp/src/main/resources/dependency-check-maven-config.xml
+++ b/support-owasp/src/main/resources/dependency-check-maven-config.xml
@@ -73,27 +73,7 @@
         CVE-2011-2730 only applies when using JSP Expression Language (EL) which is not used in DDF.
      -->
     <suppress>
-        <notes><![CDATA[
-   file name: spring-osgi-core-1.2.1.jar
-   ]]></notes>
-        <sha1>E5666DFAC49C4B0488EF3F53E6D9232783697817</sha1>
         <cve>CVE-2011-2730</cve>
     </suppress>
-
-  <suppress>
-     <notes><![CDATA[
-     file name: slf4j-api-1.7.1.jar
-     ]]></notes>
-     <sha1>1A508B0ECD360507A39A4DBAEDD1AA4750741F6D</sha1>
-     <cve>CVE-2011-2730</cve>
-  </suppress>
-
-  <suppress>
-     <notes><![CDATA[
-     file name: platform-configuration-2.3.1.jar
-     ]]></notes>
-     <sha1>8C7F125155FE93B42E98B6556A9CE90805E5AE1B</sha1>
-     <cve>CVE-2011-2730</cve>
-  </suppress>
 
 </suppressions>


### PR DESCRIPTION
PR to fix DDF nightly build failures.

@figliold, @andrewkfiedler please review.