### PR TITLE
DDF-1341: Configure Bamboo Nightly to Publish Site to Codice Nexus

### DIFF
--- a/support-bamboo/settings-site.xml
+++ b/support-bamboo/settings-site.xml
@@ -1,0 +1,37 @@
+<settings>
+
+    <servers>
+        <server>
+          <id>snapshots</id>
+          <username>ddf</username>
+          <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+        <server>
+          <id>reports</id>
+          <username>ddf</username>
+          <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+    </servers>
+
+    <profiles>
+        <profile>
+          <id>codice</id>
+          <repositories>
+            <repository>
+              <id>forgerock-staging-repository</id>
+              <name>ForgeRock Release Repository</name>
+              <url>http://artifacts.codice.org/content/groups/public/</url>
+          </repository>
+          <repository>
+              <id>forgerock-snapshots-repository</id>
+              <name>ForgeRock Snapshot Repository</name>
+              <url>http://artifacts.codice.org/content/groups/public/</url>
+          </repository>
+          </repositories>
+          <activation>
+            <activeByDefault>true</activeByDefault>
+          </activation>
+        </profile>
+    </profiles>
+
+</settings>

--- a/support-bamboo/settings-site.xml
+++ b/support-bamboo/settings-site.xml
@@ -2,35 +2,32 @@
 
     <servers>
         <server>
-          <id>snapshots</id>
-          <username>ddf</username>
-          <password>${env.NEXUS_PASSWORD}</password>
-        </server>
-        <server>
-          <id>reports</id>
-          <username>ddf</username>
-          <password>${env.NEXUS_PASSWORD}</password>
+            <id>reports</id>
+            <username>ddf</username>
+            <password>${env.NEXUS_PASSWORD}</password>
         </server>
     </servers>
 
     <profiles>
         <profile>
-          <id>codice</id>
-          <repositories>
-            <repository>
-              <id>forgerock-staging-repository</id>
-              <name>ForgeRock Release Repository</name>
-              <url>http://artifacts.codice.org/content/groups/public/</url>
-          </repository>
-          <repository>
-              <id>forgerock-snapshots-repository</id>
-              <name>ForgeRock Snapshot Repository</name>
-              <url>http://artifacts.codice.org/content/groups/public/</url>
-          </repository>
-          </repositories>
-          <activation>
-            <activeByDefault>true</activeByDefault>
-          </activation>
+            <id>codice</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <!-- These repositories override the URLs defined for the same id's in the parent pom. The forgerock repos
+            are needed for the build to succeed but cause 409 errors when used with maven site generation -->
+            <repositories>
+                <repository>
+                    <id>forgerock-staging-repository</id>
+                    <name>ForgeRock Release Repository</name>
+                    <url>http://artifacts.codice.org/content/groups/public/</url>
+                </repository>
+                <repository>
+                    <id>forgerock-snapshots-repository</id>
+                    <name>ForgeRock Snapshot Repository</name>
+                    <url>http://artifacts.codice.org/content/groups/public/</url>
+                </repository>
+            </repositories>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Added a second maven settings file to support-bamboo that overwrites the
forgerock repository URLs defined in the parent pom file. The repos are
neccessary for the build, but cause errors for the site generation.