### PR TITLE
DDF-1517: Hubot PR build script only takes into consideration the first 30 files changed

### DIFF
--- a/support-hubot/hubot-bamboo-prbuild/index.coffee
+++ b/support-hubot/hubot-bamboo-prbuild/index.coffee
@@ -63,7 +63,7 @@ module.exports = (robot) ->
                 # The DISTRO PR build builds the distro + integration tests with separate tasks.
 
                 repoDeltas = (base_url, pr_num, callback) ->
-                    robot.http(base_url + "/pulls/" + pr_num + "/files")
+                    robot.http(base_url + "/pulls/" + pr_num + "/files?per_page=100")
                     .header('Authorization', "token #{github_api_token}")
                     .get() (err, res, body) ->
                         if err


### PR DESCRIPTION
Added per_page query parameter to return 100 files, which is the upper limit.

@coyotesqrl, @andrewkfiedler, please review.