### PR TITLE
DDF-2063: PR build hubot ignoring changes to the root directory

### DIFF
--- a/support-hubot/hubot-bamboo-prbuild/index.coffee
+++ b/support-hubot/hubot-bamboo-prbuild/index.coffee
@@ -163,7 +163,7 @@ module.exports = (robot) ->
                 # a "resources" directory.
                 modules = (
                     removeFileName(obj.path) for obj in gitTree.tree when obj.path? and
-                        obj.path.match(".*/pom.xml$") and not obj.path.match(".*/resources/.*")
+                        obj.path.match(".*\\bpom.xml$") and not obj.path.match(".*/resources/.*")
                 )
 
                 # Need to reverse sort Maven modules to make sure the most specific modules are


### PR DESCRIPTION
Changed regular expression used when getting the list of Maven modules
to make sure files in the root directory are not ignored.

@brendan-hofmann @coyotesqrl 