### PR TITLE
Add feature:tree Karaf command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install: mvn install --quiet -DskipTests=true -B
-script: mvn test --quiet -B
 language: java
 jdk:
-  - openjdk7
+  - oraclejdk8
+

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>support-findbugs</module>
         <module>support-owasp</module>
         <module>support-pmd</module>
+        <module>support-karaf</module>
     </modules>
 
     <properties>

--- a/support-karaf/commands/feature-tree/pom.xml
+++ b/support-karaf/commands/feature-tree/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.support</groupId>
+        <artifactId>support-karaf-commands</artifactId>
+        <version>2.3.7-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>feature-tree</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: Platform :: Feature :: Tree</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.karaf.shell</groupId>
+            <artifactId>org.apache.karaf.shell.console</artifactId>
+            <version>${karaf.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>org.apache.karaf.features.core</artifactId>
+            <version>${karaf.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${osgi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Karaf-Commands>*</Karaf-Commands>
+                        <Embed-Dependency>
+                            commons-lang
+                        </Embed-Dependency>
+                        <Export-Package/>
+                        <Import-Package>
+                            org.osgi.framework;version="[1.5,2)",
+                            org.apache.karaf.features,
+                            org.apache.karaf.shell.api.action,
+                            org.apache.karaf.shell.api.action.lifecycle
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/support-karaf/commands/feature-tree/src/main/java/org/codice/ddf/platform/feature/impl/FeatureTreeCommand.java
+++ b/support-karaf/commands/feature-tree/src/main/java/org/codice/ddf/platform/feature/impl/FeatureTreeCommand.java
@@ -1,0 +1,105 @@
+package org.codice.ddf.platform.feature.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.karaf.features.Dependency;
+import org.apache.karaf.features.Feature;
+import org.apache.karaf.features.FeaturesService;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+@Service
+@Command(scope = "feature", name = "tree")
+public class FeatureTreeCommand implements Action {
+    @Argument(name = "Feature name", description = "Name of the feature to use as root of the feature tree.", required = true)
+    private String rootFeatureName = null;
+
+    @Option(name = "--depth", description = "How many levels deep the tree should be.", aliases = {
+            "-d"})
+    private int maxDepth = 100;
+
+    @Option(name = "--no-duplicates", description = "Do not repeat feature sub-trees that have already been displayed.", aliases = {
+            "-n"})
+    private boolean noDuplicates = false;
+
+    @Option(name = "--include-repo", description = "Include only features coming from the repositories matching this regular expression.", aliases = {
+            "-i"})
+    private String repoFilter = ".*(ddf|dib|alliance).*";
+
+    @Option(name = "--line-numbers", description = "Displays line numbers and cross-references", aliases = {
+            "-l"})
+    private boolean printLineNumbers = false;
+
+    private static int lineNumber = 1;
+
+    @Reference
+    FeaturesService featuresService;
+
+    private Map<String, Integer> subTreesAlreadyVisited = new HashMap<>();
+
+    @Override
+    public Object execute() throws Exception {
+        lineNumber = 1;
+        printDependencies(rootFeatureName, 0);
+        return null;
+    }
+
+    private void printDependencies(String name, int depth) {
+        if (depth > maxDepth) {
+            return;
+        }
+
+        Feature feature;
+
+        try {
+            feature = featuresService.getFeature(name);
+        } catch (Exception e) {
+            return;
+        }
+
+        if (feature == null || !feature.getRepositoryUrl()
+                .matches(repoFilter)) {
+            return;
+        }
+
+        if (noDuplicates && subTreesAlreadyVisited.containsKey(name)) {
+            printDependency(name, depth, true);
+            lineNumber++;
+            return;
+        }
+
+        printDependency(name, depth, false);
+        subTreesAlreadyVisited.put(name, lineNumber++);
+
+        List<Dependency> dependencies = feature.getDependencies();
+
+        for (Dependency dependency : dependencies) {
+            printDependencies(dependency.getName(), depth + 1);
+        }
+    }
+
+    private void printDependency(String name, int depth, boolean alreadyVisited) {
+        if (printLineNumbers) {
+            System.out.print(String.format("%4d - ", lineNumber));
+        }
+
+        System.out.print(String.format("%s%s", StringUtils.repeat(" ", depth * 2), name));
+
+        if (alreadyVisited) {
+            if (printLineNumbers) {
+                System.out.print(String.format(" -> %d", subTreesAlreadyVisited.get(name)));
+            } else {
+                System.out.print(" *");
+            }
+        }
+
+        System.out.println();
+    }
+}

--- a/support-karaf/commands/pom.xml
+++ b/support-karaf/commands/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.support</groupId>
+        <artifactId>support-karaf</artifactId>
+        <version>2.3.7-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>support-karaf-commands</artifactId>
+    <name>DDF Support Karaf Commands</name>
+    <description>DDF Karaf utility commands</description>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>feature-tree</module>
+    </modules>
+</project>

--- a/support-karaf/pom.xml
+++ b/support-karaf/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.support</groupId>
+        <artifactId>support-pom</artifactId>
+        <version>2.3.7-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>support-karaf</artifactId>
+    <name>DDF Support Karaf</name>
+    <description>DDF Karaf utilities</description>
+    <packaging>pom</packaging>
+
+    <properties>
+        <karaf.version>4.0.7</karaf.version>
+        <osgi.version>5.0.0</osgi.version>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <instructions>
+                            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        </instructions>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.3</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <maxmem>512M</maxmem>
+                        <fork>${compiler.fork}</fork>
+                        <encoding>${project.build.sourceEncoding}</encoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <modules>
+        <module>commands</module>
+    </modules>
+</project>


### PR DESCRIPTION
Add new `feature:tree` command that prints out the tree of dependent features given a root feature. Also adds new `support-karaf` top level Maven module and sub-modules.