### PR TITLE
DDF-2819 Add new maven-version-validation-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ddf.support</groupId>
@@ -24,7 +26,8 @@
     -->
     <version>2.3.7-SNAPSHOT</version>
     <name>DDF Support</name>
-    <description>DDF Support module contains support files for builds and site report generation</description>
+    <description>DDF Support module contains support files for builds and site report generation
+    </description>
     <packaging>pom</packaging>
 
     <modules>
@@ -34,6 +37,7 @@
         <module>support-owasp</module>
         <module>support-pmd</module>
         <module>support-karaf</module>
+        <module>support-maven-plugins</module>
     </modules>
 
     <properties>
@@ -47,7 +51,7 @@
         <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
         <maven.deploy.plugin.version>2.6</maven.deploy.plugin.version>
         <maven.install.plugin.version>2.3.1</maven.install.plugin.version>
-        <maven.surefire.plugin.version>2.8.1</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
     </properties>
 
     <scm>
@@ -127,6 +131,7 @@
         </pluginManagement>
 
         <plugins>
+
         </plugins>
     </build>
 

--- a/support-maven-plugins/pom.xml
+++ b/support-maven-plugins/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>support-pom</artifactId>
+        <groupId>ddf.support</groupId>
+        <version>2.3.7-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>maven-plugin</packaging>
+
+    <artifactId>version-validation-plugin</artifactId>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-json_1.0_spec</artifactId>
+            <version>1.0-alpha-1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>3.0-alpha-2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.3.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/support-maven-plugins/pom.xml
+++ b/support-maven-plugins/pom.xml
@@ -43,6 +43,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.5</version>
@@ -52,11 +57,11 @@
             <artifactId>plexus-utils</artifactId>
             <version>3.0.8</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.0_spec</artifactId>
-            <version>1.0-alpha-1</version>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.geronimo.specs</groupId>-->
+            <!--<artifactId>geronimo-json_1.0_spec</artifactId>-->
+            <!--<version>1.0-alpha-1</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-project</artifactId>

--- a/support-maven-plugins/pom.xml
+++ b/support-maven-plugins/pom.xml
@@ -72,7 +72,6 @@
             <artifactId>maven-core</artifactId>
             <version>3.3.9</version>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/support-maven-plugins/src/main/java/org/codice/plugin/version/MavenVersionValidationPlugin.java
+++ b/support-maven-plugins/src/main/java/org/codice/plugin/version/MavenVersionValidationPlugin.java
@@ -41,7 +41,10 @@ import org.codehaus.plexus.util.DirectoryScanner;
 @Mojo(name = "check-package-json")
 public class MavenVersionValidationPlugin extends AbstractMojo {
 
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    @Parameter(property="whitelistedValues")
+    private String[] whitelistedValues;
+
+    @Parameter(defaultValue = "${project}")
     MavenProject project;
 
     Set<Character> rangeSymbols = new HashSet(Arrays.asList('>', '=', '|', '-', '<', '^', '~'));
@@ -169,20 +172,31 @@ public class MavenVersionValidationPlugin extends AbstractMojo {
      * @return Range character or null (if valid range)
      */
     String scanTokenForRangeSymbol(String token) {
-        if (token.contains("-beta") || token.contains("#")) {
-            return null;
+        for (String whitelistValue : getWhitelistedValues())
+        {
+            if (token.contains(whitelistValue)) {
+                return null;
+            }
         }
 
         if (!token.matches(".*\\d+[.]\\d+.*")) {
             return null;
         }
 
-        for (char character: token.toCharArray()) {
+        for (char character : token.toCharArray()) {
             if (rangeSymbols.contains(character)) {
                 return String.valueOf(character);
             }
         }
 
         return null;
+    }
+
+    public String[] getWhitelistedValues() {
+        return whitelistedValues;
+    }
+
+    public void setWhitelistedValues(String[] whitelistedValues) {
+        this.whitelistedValues = whitelistedValues;
     }
 }

--- a/support-maven-plugins/src/main/java/org/codice/plugin/version/MavenVersionValidationPlugin.java
+++ b/support-maven-plugins/src/main/java/org/codice/plugin/version/MavenVersionValidationPlugin.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General private License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General private License for more details. A copy of the GNU Lesser General private License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.plugin.version;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.DirectoryScanner;
+
+@Mojo(name = "check-package-json")
+public class MavenVersionValidationPlugin extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    MavenProject project;
+
+    Set<Character> rangeSymbols = new HashSet(Arrays.asList('>', '=', '|', '-', '<', '^', '~'));
+
+    private final static String[] EXCLUDED_DIRECTORIES =
+            new String[] {"**/node_modules/**", "**/node/**", "*/target/**", "**\\node_modules\\**",
+                    "**\\node\\**", "**\\target\\**"};
+
+    private final static String FILE_NAME = "package.json";
+
+    private final static String MOJO_EXCEPTION_MESSAGE =
+            "Failed to validate version due to improper range symbol.";
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        String jsonContents;
+        File jsonFile;
+        boolean hasRangeChars = false;
+
+        JsonObject jsonObject;
+
+        String baseDir = null;
+        try {
+            baseDir = project.getBasedir()
+                    .getCanonicalPath();
+        } catch (IOException e) {
+            getLog().error("Could not find base directory", e);
+        }
+
+        if (baseDir != null) {
+            String[] fileList = getListOfPackageJsonFiles(baseDir, FILE_NAME);
+
+            for (String filepath : fileList) {
+                jsonFile = Paths.get(baseDir, File.separator, filepath)
+                        .toFile();
+
+                try {
+                    jsonContents = FileUtils.readFileToString(jsonFile, (Charset) null);
+                    JsonReader jsonReader = Json.createReader(new StringReader(jsonContents));
+                    jsonObject = jsonReader.readObject();
+
+                    hasRangeChars |= hasRangeChars(jsonObject.getJsonObject("devDependencies"),
+                            jsonFile.toString());
+                    hasRangeChars |= hasRangeChars(jsonObject.getJsonObject("dependencies"),
+                            jsonFile.toString());
+                } catch (IOException e) {
+                    getLog().error("Could not find file", e);
+                }
+            }
+            if (hasRangeChars) {
+                throw new MojoFailureException(MOJO_EXCEPTION_MESSAGE);
+            }
+        }
+    }
+
+    /**
+     * Uses DirectoryScanner to search for given filename in baseDir given, excluding string
+     * array of excluded regular expression paths. Returns list of full file paths (minus baseDir)
+     *
+     * @param baseDir:  Base directory of scanning (depends on project)
+     * @param filename: Name of file to search for (regex)
+     * @return list of files
+     */
+    private String[] getListOfPackageJsonFiles(String baseDir, String filename) {
+
+        DirectoryScanner scanner = new DirectoryScanner();
+
+        scanner.setIncludes(new String[] {"**/*" + filename});
+        scanner.setExcludes(EXCLUDED_DIRECTORIES);
+        scanner.setBasedir(baseDir);
+        scanner.scan();
+
+        return scanner.getIncludedFiles();
+    }
+
+    /**
+     * Extracts key and value from JsonObject and evaluates if contains bad range symbol
+     * key: dependency name
+     * value: version number
+     *
+     * @param jsonObject: Incoming Json structure to parse (key-value pairs)
+     * @param filename:   File being parsed (used for name in error message)
+     * @return true if there are version range characters in the file
+     */
+    private boolean hasRangeChars(JsonObject jsonObject, String filename)
+            throws MojoFailureException {
+        // (ex. key = "babel-core", value = "^6.17.0")
+        String key;
+        String value;
+        String rangeChar;
+        String errorMessage;
+
+        boolean hasRangeChar = false;
+
+        if (jsonObject == null) {
+            return false;
+        }
+
+        for (Map.Entry<String, JsonValue> entry : jsonObject.entrySet()) {
+
+            key = entry.getKey();
+            value = entry.getValue()
+                    .toString();
+
+            rangeChar = scanTokenForRangeSymbol(value);
+
+            if (rangeChar != null) {
+                errorMessage = String.format(
+                        "In [%s] | Invalid version range symbol: [%s] in [%s] : %s",
+                        filename,
+                        rangeChar,
+                        key,
+                        value);
+                getLog().error(errorMessage);
+                hasRangeChar = true;
+            }
+        }
+        return hasRangeChar;
+    }
+
+    /**
+     * Scans token for bad symbols which denotes a range being used.
+     * Returns character being used as range symbol.
+     *
+     * @param token Input string which is checked for range symbol
+     * @return Range character or null (if valid range)
+     */
+    String scanTokenForRangeSymbol(String token) {
+        if (token.contains("-beta") || token.contains("#")) {
+            return null;
+        }
+
+        if (!token.matches(".*\\d+[.]\\d+.*")) {
+            return null;
+        }
+
+        for (char character: token.toCharArray()) {
+            if (rangeSymbols.contains(character)) {
+                return String.valueOf(character);
+            }
+        }
+
+        return null;
+    }
+}

--- a/support-maven-plugins/src/main/java/org/codice/plugin/version/MavenVersionValidationPlugin.java
+++ b/support-maven-plugins/src/main/java/org/codice/plugin/version/MavenVersionValidationPlugin.java
@@ -41,7 +41,7 @@ import org.codehaus.plexus.util.DirectoryScanner;
 @Mojo(name = "check-package-json")
 public class MavenVersionValidationPlugin extends AbstractMojo {
 
-    @Parameter(property="whitelistedValues")
+    @Parameter(property = "whitelistedValues")
     private String[] whitelistedValues;
 
     @Parameter(defaultValue = "${project}")
@@ -172,8 +172,7 @@ public class MavenVersionValidationPlugin extends AbstractMojo {
      * @return Range character or null (if valid range)
      */
     String scanTokenForRangeSymbol(String token) {
-        for (String whitelistValue : getWhitelistedValues())
-        {
+        for (String whitelistValue : getWhitelistedValues()) {
             if (token.contains(whitelistValue)) {
                 return null;
             }

--- a/support-maven-plugins/src/test/java/org/codice/plugin/version/MavenVersionValidationPluginTest.java
+++ b/support-maven-plugins/src/test/java/org/codice/plugin/version/MavenVersionValidationPluginTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General private License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General private License for more details. A copy of the GNU Lesser General private License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.plugin.version;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class MavenVersionValidationPluginTest {
+
+    @Test
+    public void testInvalidInputs() {
+        List<String> invalidInputs = Arrays.asList("^2.3.1",
+                "~2.3.1",
+                "<2.3.1",
+                "<=2.3.1",
+                "2.3.1-5.6",
+                ">=2.3.1 || 4.1.0",
+                "2.3.1 || >4.1.0",
+                "2.3.1 || 4.1.0");
+
+        MavenVersionValidationPlugin mvnPlugin = new MavenVersionValidationPlugin();
+
+        for (String testInputVersion : invalidInputs) {
+            assertThat("Assert that each character is properly output as invalid",
+                    mvnPlugin.scanTokenForRangeSymbol(testInputVersion),
+                    notNullValue());
+        }
+    }
+
+    @Test
+    public void testValidInputs() {
+        List<String> validInputs = Arrays.asList(
+                "2.3.1",
+                "2.3",
+                "2.3-beta2",
+                "bower",
+                "349874875jdakjlfkjadsf#jdfaisdf",
+                "3.5.3jdakjlfkjadsf#jdfaisdf");
+
+        MavenVersionValidationPlugin mvnPlugin = new MavenVersionValidationPlugin();
+
+        for (String testInputVersion : validInputs) {
+            assertThat("Assert that good version returns null",
+                    mvnPlugin.scanTokenForRangeSymbol(testInputVersion),
+                    nullValue());
+        }
+    }
+}

--- a/support-maven-plugins/src/test/java/org/codice/plugin/version/MavenVersionValidationPluginTest.java
+++ b/support-maven-plugins/src/test/java/org/codice/plugin/version/MavenVersionValidationPluginTest.java
@@ -48,13 +48,13 @@ public class MavenVersionValidationPluginTest {
 
     @Test
     public void testValidInputs() {
-        List<String> validInputs = Arrays.asList(
-                "2.3.1",
+        List<String> validInputs = Arrays.asList("2.3.1",
                 "2.3",
                 "2.3-beta2",
                 "bower",
                 "349874875jdakjlfkjadsf#jdfaisdf",
-                "3.5.3jdakjlfkjadsf#jdfaisdf");
+                "3.5.3jdakjlfkjadsf#jdfaisdf",
+                "Eonasdan/bootstrap-datetimepicker#4.17.37");
 
         MavenVersionValidationPlugin mvnPlugin = new MavenVersionValidationPlugin();
         mvnPlugin.setWhitelistedValues(new String[] {"-beta", "#"});

--- a/support-maven-plugins/src/test/java/org/codice/plugin/version/MavenVersionValidationPluginTest.java
+++ b/support-maven-plugins/src/test/java/org/codice/plugin/version/MavenVersionValidationPluginTest.java
@@ -37,6 +37,7 @@ public class MavenVersionValidationPluginTest {
                 "2.3.1 || 4.1.0");
 
         MavenVersionValidationPlugin mvnPlugin = new MavenVersionValidationPlugin();
+        mvnPlugin.setWhitelistedValues(new String[] {"-beta", "#"});
 
         for (String testInputVersion : invalidInputs) {
             assertThat("Assert that each character is properly output as invalid",
@@ -56,6 +57,7 @@ public class MavenVersionValidationPluginTest {
                 "3.5.3jdakjlfkjadsf#jdfaisdf");
 
         MavenVersionValidationPlugin mvnPlugin = new MavenVersionValidationPlugin();
+        mvnPlugin.setWhitelistedValues(new String[] {"-beta", "#"});
 
         for (String testInputVersion : validInputs) {
             assertThat("Assert that good version returns null",


### PR DESCRIPTION
#### What does this PR do?
Creates new maven plugin which scans a project at build-time for any package.json files which incorrectly use version ranges for dependencies. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @emanns95 @AzGoalie @vinamartin 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Will need to pull in ddf pom.xml commit as well (https://github.com/codice/ddf/pull/1744) for the plugin to be testable, and then run `mvn verify` in DDF. Successful if verify errors out with a MojoException due to incorrect version range symbols. 

#### Any background context you want to provide?
Version ranges expose the codebase to potential vulnerabilities, unlike sticking to exact, known versions of dependencies. 

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2819)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
