### PR TITLE
DDF-3219 Disallows '*' imports.

### DIFF
--- a/support-checkstyle/src/main/resources/checkstyle-enforced.xml
+++ b/support-checkstyle/src/main/resources/checkstyle-enforced.xml
@@ -81,6 +81,7 @@
 
 		<!-- Checks for imports                              -->
 		<!-- See http://checkstyle.sf.net/config_import.html -->
+		<module name="AvoidStarImport"/>
 		<module name="IllegalImport"/> <!-- defaults to sun.* packages -->
 		<module name="RedundantImport"/>
 


### PR DESCRIPTION
This reverses a change that should not have been made in version 2.3.10.