### PR TITLE
DDF-3805 Added support for @SuppressWarnings and inline suppression comments for checkstyle

### DIFF
--- a/support-checkstyle/src/main/resources/checkstyle-enforced.xml
+++ b/support-checkstyle/src/main/resources/checkstyle-enforced.xml
@@ -16,6 +16,13 @@
 
 
 <module name="Checker">
+	<!-- Supports @SuppressWarnings() annotations -->
+	<module name="SuppressWarningsFilter"/>
+	<!-- Supports one line suppression such as // suppress checkstyle:IllegalImport special package required -->
+	<module name="SuppressWithNearbyCommentFilter">
+		<property name="commentFormat" value="suppress checkstyle:(\w+(\|\w+)*)"/>
+		<property name="checkFormat" value="$1"/>
+	</module>
 
     <!--XML Header checks -->
     <module name="RegexpHeader">
@@ -41,6 +48,10 @@
 	</module>
 
 	<module name="TreeWalker">
+		<!-- Supports @SuppressWarnings() annotations -->
+		<module name="SuppressWarningsHolder" />
+		<!-- Supports inline suppression comments -->
+		<module name="FileContentsHolder"/>
 
 		<!-- Checks for Javadoc comments.                              -->
 		<!-- See http://checkstyle.sourceforge.net/config_javadoc.html -->
@@ -78,10 +89,10 @@
 			<property name="severity" value="warning"/>
 		</module>
 
-                <!-- Checks for imports                                        -->
-                <!-- See http://checkstyle.sourceforge.net/config_imports.html -->
-                <module name="AvoidStarImport"/>
-                <module name="IllegalImport"/>
+		<!-- Checks for imports                                        -->
+		<!-- See http://checkstyle.sourceforge.net/config_imports.html -->
+		<module name="AvoidStarImport"/>
+		<module name="IllegalImport"/>
                 
 		<!-- Checks for Size Violations.                             -->
 		<!-- See http://checkstyle.sourceforge.net/config_sizes.html -->


### PR DESCRIPTION
#### What does this PR do?
Added support for @SuppressWarnings and inline suppression comments for checkstyle
For example:
```import sun.security.x509.X509CertImpl; // suppress checkstyle:IllegalImport required for testing```

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@mackncheesiest  
@jhunzik 
@figliold 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@tbatie 
@shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
- Run ddf-support build and all should pass

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3805](https://codice.atlassian.net/browse/DDF-3805)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
