### PR TITLE
DDF-5855 Creating maven plugin to enforce bundle import versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install: mvn install --quiet -DskipTests=true -B
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 

--- a/support-maven/bundle-validation-plugin/pom.xml
+++ b/support-maven/bundle-validation-plugin/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>ddf.support</groupId>
+        <artifactId>support-maven</artifactId>
+        <version>2.3.17-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>maven-plugin</packaging>
+
+    <artifactId>bundle-validation-plugin</artifactId>
+
+    <name>Bundle Import Version Validation Plugin</name>
+    <description>Utility for enforcing OSGi bundle import versions</description>
+
+    <properties>
+        <commons-lang3.version>3.4</commons-lang3.version>
+        <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
+        <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
+        <maven.core.version>3.6.0</maven.core.version>
+        <junit.version>4.12</junit.version>
+        <mockito-all.version>1.10.19</mockito-all.version>
+        <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven.plugin.annotations.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito-all.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven.plugin.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${maven.jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.73</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
+++ b/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
@@ -150,15 +150,14 @@ public class BundleImportValidationPlugin extends AbstractMojo {
           .collect(Collectors.toList());
     }
 
-    if (CONFIG_OPTION_TO_VALIDATE.equals(current.getName())) {
-      List<ValidationResult> results = validateImports(current.getValue());
-      if (results.isEmpty()) {
-        return Collections.singletonList(new ValidationResult("No Packages Imported", true));
-      }
-      return results;
-    } else {
+    if (!CONFIG_OPTION_TO_VALIDATE.equals(current.getName())) {
       return Collections.emptyList();
     }
+    List<ValidationResult> results = validateImports(current.getValue());
+    if (results.isEmpty()) {
+      return Collections.singletonList(new ValidationResult("No Packages Imported", true));
+    }
+    return results;
   }
 
   private List<ValidationResult> validateImports(String importString) {
@@ -185,15 +184,15 @@ public class BundleImportValidationPlugin extends AbstractMojo {
     getLog().info("Testing import: " + line);
 
     ValidationResult validationResult = new ValidationResult(line, IS_VALID_IMPORT.test(line));
-
-    if (!validationResult.isValid()) {
-      if (warnOnlyModules.contains(project.getArtifactId()) || warnOnlyModules.contains("*")) {
-        getLog().warn("Import with missing version found: " + line);
-      } else {
-        getLog().error("Import with missing version found: " + line);
-      }
+    if (validationResult.isValid()) {
+      return validationResult;
     }
 
+    if (warnOnlyModules.contains(project.getArtifactId()) || warnOnlyModules.contains("*")) {
+      getLog().warn("Import with missing version found: " + line);
+    } else {
+      getLog().error("Import with missing version found: " + line);
+    }
     return validationResult;
   }
 
@@ -212,10 +211,11 @@ public class BundleImportValidationPlugin extends AbstractMojo {
 
     if (validationResults.isEmpty()) {
       validationResultSummary.append("Invalid  -  ").append(NO_PACKAGE_IMPORTS_FOUND).append("\n");
-    } else {
-      for (ValidationResult result : validationResults) {
-        validationResultSummary.append(result).append("\n");
-      }
+      return validationResultSummary;
+    }
+
+    for (ValidationResult result : validationResults) {
+      validationResultSummary.append(result).append("\n");
     }
     return validationResultSummary;
   }

--- a/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
+++ b/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.plugin.bundle;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+@Mojo(
+    name = "validate-import-versions",
+    defaultPhase = LifecyclePhase.INITIALIZE,
+    threadSafe = true)
+public class BundleImportValidationPlugin extends AbstractMojo {
+
+  private static final String OUTPUT_FILENAME = "bundleImportValidationResults.txt";
+
+  private static final String FAILURE_SUMMARY_FILENAME = "importVersionValidationFailures.txt";
+
+  private static final String CONFIG_OPTION_TO_VALIDATE = "Import-Package";
+
+  private static final Predicate<String> IS_VALID_IMPORT =
+      importString -> importString.contains("version=");
+
+  private static final Predicate<String> IS_NOT_IGNORED_IMPORT = value -> !value.startsWith("!");
+
+  private static final String NO_PACKAGE_IMPORTS_FOUND =
+      "No package imports specified; this defaults to a * import";
+
+  private static final Pattern IMPORT_VALUE_PATTERN = Pattern.compile("[^,\"]*\"[^\"]*\"|[^,]+");
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  private MavenProject project;
+
+  @Parameter(defaultValue = "${}")
+  private List<String> excludedModules;
+
+  @Parameter(defaultValue = "${}")
+  private List<String> warnOnlyModules;
+
+  @Parameter(defaultValue = "true")
+  private boolean writeModuleResultsToTarget;
+
+  @Parameter private String failureSummaryDirectory;
+
+  @Override
+  public void execute() throws MojoFailureException {
+    if (excludedModules.contains(project.getArtifactId())) {
+      getLog().info("Skipping import validation for excluded module " + project.getName());
+      return;
+    }
+    Plugin mavenBundlePlugin = getMavenBundlePlugin();
+    if (mavenBundlePlugin == null) {
+      getLog()
+          .info(
+              "Skipping import validation; bundle plugin not configured for " + project.getName());
+      return;
+    }
+
+    List<ValidationResult> validationResults = validateConfiguredImports(mavenBundlePlugin);
+    if (writeModuleResultsToTarget) {
+      writeTargetOutput(validationResults);
+    }
+
+    List<ValidationResult> failures =
+        validationResults.stream().filter(result -> !result.isValid).collect(Collectors.toList());
+
+    if (failures.isEmpty() && !validationResults.isEmpty()) {
+      getLog().info("All import versions appear valid in " + project.getName());
+      return;
+    }
+
+    getLog().warn("Bundle version validation failed for " + project.getName());
+    if (validationResults.isEmpty()) {
+      getLog().warn(NO_PACKAGE_IMPORTS_FOUND);
+    }
+
+    if (StringUtils.isNotBlank(failureSummaryDirectory)) {
+      writeFailureSummary(failures);
+    }
+
+    if (!warnOnlyModules.contains(project.getArtifactId()) && !warnOnlyModules.contains("*")) {
+      throw new MojoFailureException("Invalid bundle version configured in " + project.getName());
+    }
+  }
+
+  List<ValidationResult> validateConfiguredImports(Plugin mavenBundlePlugin) {
+    getLog().info("Validating import versions in " + project.getName());
+
+    Xpp3Dom bundlePluginConfig = (Xpp3Dom) mavenBundlePlugin.getConfiguration();
+    return Arrays.stream(bundlePluginConfig.getChildren())
+        .map(this::validateConfig)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
+  void setProject(MavenProject project) {
+    this.project = project;
+  }
+
+  void setExcludedModules(List<String> excludedModules) {
+    this.excludedModules = excludedModules;
+  }
+
+  void setWarnOnlyModules(List<String> warnOnlyModules) {
+    this.warnOnlyModules = warnOnlyModules;
+  }
+
+  private Plugin getMavenBundlePlugin() {
+    return project.getBuildPlugins().stream()
+        .filter(plugin -> "maven-bundle-plugin".equals(plugin.getArtifactId()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private List<ValidationResult> validateConfig(Xpp3Dom current) {
+    if (current.getChildCount() > 0) {
+      return Arrays.stream(current.getChildren())
+          .filter(child -> CONFIG_OPTION_TO_VALIDATE.equals(child.getName()))
+          .map(this::validateConfig)
+          .flatMap(Collection::stream)
+          .collect(Collectors.toList());
+    }
+
+    if (CONFIG_OPTION_TO_VALIDATE.equals(current.getName())) {
+      List<ValidationResult> results = validateImports(current.getValue());
+      if (results.isEmpty()) {
+        return Collections.singletonList(new ValidationResult("No Packages Imported", true));
+      }
+      return results;
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  private List<ValidationResult> validateImports(String importString) {
+    if (StringUtils.isBlank(importString)) {
+      return Collections.emptyList();
+    }
+    return extractImports(importString).stream()
+        .map(String::trim)
+        .filter(IS_NOT_IGNORED_IMPORT)
+        .map(this::validate)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractImports(String line) {
+    List<String> imports = new ArrayList<>();
+    Matcher m = IMPORT_VALUE_PATTERN.matcher(line);
+    while (m.find()) {
+      imports.add(m.group());
+    }
+    return imports;
+  }
+
+  private ValidationResult validate(String line) {
+    getLog().info("Testing import: " + line);
+
+    ValidationResult validationResult = new ValidationResult(line, IS_VALID_IMPORT.test(line));
+
+    if (!validationResult.isValid()) {
+      if (warnOnlyModules.contains(project.getArtifactId()) || warnOnlyModules.contains("*")) {
+        getLog().warn("Import with missing version found: " + line);
+      } else {
+        getLog().error("Import with missing version found: " + line);
+      }
+    }
+
+    return validationResult;
+  }
+
+  private void writeTargetOutput(List<ValidationResult> validationResults) {
+    String targetDir = project.getBuild().getDirectory();
+    StringBuilder validationResultSummary = buildValidationResultSummary(validationResults);
+    writeToFile(targetDir, OUTPUT_FILENAME, validationResultSummary);
+  }
+
+  StringBuilder buildValidationResultSummary(List<ValidationResult> validationResults) {
+    StringBuilder validationResultSummary = new StringBuilder();
+    validationResultSummary
+        .append("Import validation results for ")
+        .append(project.getName())
+        .append("\n\n");
+
+    if (validationResults.isEmpty()) {
+      validationResultSummary.append("Invalid  -  ").append(NO_PACKAGE_IMPORTS_FOUND).append("\n");
+    } else {
+      for (ValidationResult result : validationResults) {
+        validationResultSummary.append(result).append("\n");
+      }
+    }
+    return validationResultSummary;
+  }
+
+  private void writeFailureSummary(List<ValidationResult> failures) {
+    StringBuilder failureSummary = new StringBuilder();
+    failureSummary.append("Invalid imports found in ").append(project.getName()).append("\n");
+
+    if (failures.isEmpty()) {
+      failureSummary.append(NO_PACKAGE_IMPORTS_FOUND).append("\n\n");
+    } else {
+      for (ValidationResult failure : failures) {
+        failureSummary.append(failure.importString).append("\n");
+      }
+      failureSummary.append(failures.size()).append(" import(s) with no version.\n\n");
+    }
+
+    synchronized (BundleImportValidationPlugin.class) {
+      writeToFile(failureSummaryDirectory, FAILURE_SUMMARY_FILENAME, failureSummary);
+    }
+  }
+
+  private void writeToFile(String path, String fileName, CharSequence output) {
+    boolean created = new File(path).mkdirs();
+    if (created) {
+      getLog().info("Created directory for: " + path);
+    }
+
+    File file = new File(path, fileName);
+    getLog().info("Writing output to: " + file.getAbsolutePath());
+
+    try (FileWriter fileWriter = new FileWriter(file, true)) {
+      fileWriter.append(output);
+    } catch (IOException e) {
+      getLog().warn("Failed to write output to: " + file.getAbsolutePath(), e);
+    }
+  }
+
+  static class ValidationResult {
+    private final String importString;
+    private final boolean isValid;
+
+    ValidationResult(String value, boolean isValid) {
+      this.importString = value;
+      this.isValid = isValid;
+    }
+
+    public String toString() {
+      String valid = isValid ? "Valid" : "Invalid";
+      return String.format("%-9s-  %s", valid, importString);
+    }
+
+    public boolean isValid() {
+      return this.isValid;
+    }
+  }
+}

--- a/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
+++ b/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
@@ -37,7 +37,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 @Mojo(
     name = "validate-import-versions",
-    defaultPhase = LifecyclePhase.INITIALIZE,
+    defaultPhase = LifecyclePhase.VALIDATE,
     threadSafe = true)
 public class BundleImportValidationPlugin extends AbstractMojo {
 
@@ -55,7 +55,8 @@ public class BundleImportValidationPlugin extends AbstractMojo {
   private static final String NO_PACKAGE_IMPORTS_FOUND =
       "No package imports specified; this defaults to a * import";
 
-  private static final Pattern IMPORT_VALUE_PATTERN = Pattern.compile("[^,\"]*\"[^\"]*\"|[^,]+");
+  private static final Pattern IMPORT_VALUE_PATTERN =
+      Pattern.compile("(?:[^,\\\"]+|(?:\\\"[^\\\"]*\\\"))+|[^,]+");
 
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   private MavenProject project;

--- a/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
+++ b/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
@@ -1,16 +1,16 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
- * General private License as published by the Free Software Foundation, either version 3 of the
- * License, or any later version.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General private License for more details. A copy of the GNU Lesser General private License
- * is distributed along with this program and can be found at
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- **/
+ */
 package org.codice.plugin.bundle;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
+++ b/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General private License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General private License for more details. A copy of the GNU Lesser General private License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.plugin.bundle;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.codice.plugin.bundle.BundleImportValidationPlugin.ValidationResult;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BundleImportValidationPluginTest {
+
+  private static final String MAVEN_BUNDLE_PLUGIN = "maven-bundle-plugin";
+
+  private static final String ARTIFACT_ID = "artifact";
+
+  private static final String VALID_CONFIG = "validConfig.txt";
+
+  private static final String INVALID_CONFIG = "invalidConfig.txt";
+
+  private static final String NO_IMPORT_CONFIG = "noImportConfig.txt";
+
+  private MavenProject project;
+
+  private BundleImportValidationPlugin validationPlugin;
+
+  @Before
+  public void setUp() {
+    project = mock(MavenProject.class);
+    validationPlugin = new BundleImportValidationPlugin();
+    validationPlugin.setProject(project);
+    validationPlugin.setExcludedModules(Collections.emptyList());
+    validationPlugin.setWarnOnlyModules(Collections.emptyList());
+    when(project.getName()).thenReturn("project");
+    when(project.getArtifactId()).thenReturn(ARTIFACT_ID);
+  }
+
+  @Test
+  public void testNoBuildPluginSucceeds() throws Exception {
+    when(project.getBuildPlugins()).thenReturn(Collections.emptyList());
+    validationPlugin.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void testInvalidConfigFails() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void testConfigWithoutImportFails() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(NO_IMPORT_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+  }
+
+  @Test
+  public void testValidConfigSucceeds() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(VALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    assertThat(results.size(), is(2));
+  }
+
+  @Test
+  public void testInvalidConfigSucceedsIfWarnOnly() throws Exception {
+    validationPlugin.setWarnOnlyModules(Collections.singletonList(ARTIFACT_ID));
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    List<ValidationResult> failures =
+        results.stream().filter(result -> !result.isValid()).collect(Collectors.toList());
+    assertThat(results.size(), is(3));
+    assertThat(failures.size(), is(2));
+  }
+
+  @Test
+  public void testInvalidConfigSucceedsIfExcluded() throws Exception {
+    validationPlugin.setExcludedModules(Collections.singletonList(ARTIFACT_ID));
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+
+    verify(project, times(0)).getBuildPlugins();
+  }
+
+  @Test
+  public void testBuildValidationSummary() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    StringBuilder summary = validationPlugin.buildValidationResultSummary(results);
+    assertThat(summary.toString().contains("Valid"), is(true));
+    assertThat(summary.toString().contains("Invalid"), is(true));
+  }
+
+  @Test
+  public void testBuildValidationSummaryNoImports() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(NO_IMPORT_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    StringBuilder summary = validationPlugin.buildValidationResultSummary(results);
+    assertThat(summary.toString().contains("No package imports specified"), is(true));
+    assertThat(summary.toString().contains("Valid"), is(false));
+  }
+}

--- a/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
+++ b/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
@@ -102,7 +102,7 @@ public class BundleImportValidationPluginTest {
     validationPlugin.execute();
 
     List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
-    assertThat(results.size(), is(2));
+    assertThat(results.size(), is(4));
   }
 
   @Test

--- a/support-maven/bundle-validation-plugin/src/test/resources/invalidConfig.txt
+++ b/support-maven/bundle-validation-plugin/src/test/resources/invalidConfig.txt
@@ -1,0 +1,11 @@
+<configuration>
+    <instructions>
+        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+        <Import-Package>
+            package1,
+            package2;version="[1.0,3)",
+            !package3,
+            *
+        </Import-Package>
+    </instructions>
+</configuration>

--- a/support-maven/bundle-validation-plugin/src/test/resources/noImportConfig.txt
+++ b/support-maven/bundle-validation-plugin/src/test/resources/noImportConfig.txt
@@ -1,0 +1,6 @@
+<configuration>
+    <instructions>
+        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+        <Export-Package>somePackage</Export-Package>
+    </instructions>
+</configuration>

--- a/support-maven/bundle-validation-plugin/src/test/resources/validConfig.txt
+++ b/support-maven/bundle-validation-plugin/src/test/resources/validConfig.txt
@@ -2,8 +2,9 @@
     <instructions>
         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
         <Import-Package>
-            package1;version="[5.5,6.2)",
-            package2;version="[1.0,3)",
+            package1;version="[5.5,6.2)", package2;version="[1.0,3)",
+            org.eclipse.jdt.ui;bundle-symbolic-name="jdt-ui";version="[1.3,2.0)";resolution:=dynamic,
+            com.acme.foo;version=1.0.0,
             !package3
         </Import-Package>
     </instructions>

--- a/support-maven/bundle-validation-plugin/src/test/resources/validConfig.txt
+++ b/support-maven/bundle-validation-plugin/src/test/resources/validConfig.txt
@@ -1,0 +1,10 @@
+<configuration>
+    <instructions>
+        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+        <Import-Package>
+            package1;version="[5.5,6.2)",
+            package2;version="[1.0,3)",
+            !package3
+        </Import-Package>
+    </instructions>
+</configuration>

--- a/support-maven/pom.xml
+++ b/support-maven/pom.xml
@@ -27,6 +27,7 @@
     <modules>
         <module>version-validation-plugin</module>
         <module>artifact-size-enforcer</module>
+        <module>bundle-validation-plugin</module>
     </modules>
     
 </project>


### PR DESCRIPTION
#### What does this PR do?
Creates a maven plugin that validates the `Import-Package` section of the configuration for the Maven Bundle Plugin. When imports without versions are found in a module, the plugin will fail the build unless it is configured to only warn for the current module (or `*`). Optionally, reports can be built for validation results/failures. 

Tests for the regex used to extract an individual import statement (separate on commas that are not in quotes): https://regex101.com/r/SFFuZ7/3

Failure report output for ddf: 
[importVersionValidationFailures.txt](https://github.com/codice/ddf-support/files/4259009/importVersionValidationFailures.txt)


#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
-->
@AzGoalie 
@aj-brooks 
@bdeining 
@bennuttle 
@leo-sakh 
@lavoywj 
@pklinef 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Can add the plugin to a pom file like this (make sure the ddf-support version in the project matches the ddf-support version you built): 
```
<plugin>
    <groupId>ddf.support</groupId>
    <artifactId>bundle-validation-plugin</artifactId>
    <version>${ddf.support.version}</version>
    <executions>
        <execution>
            <goals>
                <goal>validate-import-versions</goal>
            </goals>
            <configuration>
                <warnOnlyModules>*</warnOnlyModules>
                <failureSummaryDirectory>${user.dir}/target</failureSummaryDirectory>
            </configuration>
        </execution>
    </executions>
</plugin>
```

#### What are the relevant tickets?
Fixes: https://github.com/codice/ddf/issues/5855

#### Screenshots
<!--(if appropriate)-->
![image](https://user-images.githubusercontent.com/25469735/75402847-33413580-58c3-11ea-99af-4ffb9dc43aa1.png)
